### PR TITLE
feat(content): rework and improve error handling

### DIFF
--- a/src/lib/api/trpc.ts
+++ b/src/lib/api/trpc.ts
@@ -1,5 +1,6 @@
 import type { AppRouter } from '$lib/backend/trpc/router';
 import { DEFAULT_REQUEST_RETRIES, STORY_CONTENT_FETCH_RETRIES } from '$lib/configs/client';
+import { is4xxError } from '$lib/utils/http';
 import {
   createTRPCClient,
   httpLink,
@@ -69,10 +70,6 @@ function shouldRetry({
   }
 
   return true;
-}
-
-function is4xxError(code?: number | undefined): boolean {
-  return code !== undefined && code >= 400 && code < 500;
 }
 
 function calculateRetryDelay(attempts: number): number {

--- a/src/lib/backend/content/news.spec.ts
+++ b/src/lib/backend/content/news.spec.ts
@@ -1,7 +1,8 @@
+import { FetchError, OptimizedContentIsEmptyError } from '$lib/errors/errors';
+import { Either } from 'effect';
+import prettier from 'prettier';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { fetchStoryContent } from './news';
-import prettier from 'prettier';
-import { ContentNotFoundError, OptimizedContentIsEmptyError } from '$lib/errors/errors';
 
 interface CustomMatchers<R = unknown> {
   toBeHtml: (expected: string) => Promise<R>;
@@ -52,7 +53,7 @@ const {
     mockReadMoreArticleUrl: readMoreArticleUrl,
     mockReadMoreArticleSource: readMoreArticleSource,
     mockedFetch: vi.fn(),
-    mockedSearchStory: vi.fn().mockImplementation((url) => {
+    mockedSearchStory: vi.fn().mockImplementation(async (url) => {
       if (url === readMoreArticleUrl) {
         return readMoreStory;
       } else {
@@ -91,7 +92,8 @@ describe('News content', () => {
     test('simple article', async () => {
       mockArticle('<p>Hello World</p>');
 
-      const { content } = await fetchStoryContent(mockArticleUrl);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
 
       await expect(content).toBeHtml('<div id="readability-page-1" class="page"><p>Hello World</p></div>');
     });
@@ -99,13 +101,28 @@ describe('News content', () => {
     test('empty article', async () => {
       mockArticle('');
 
-      await expect(fetchStoryContent(mockArticleUrl)).rejects.toThrowError(OptimizedContentIsEmptyError);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const error = Either.isLeft(result) ? result.left : undefined;
+
+      expect(error).toEqual(
+        new OptimizedContentIsEmptyError({
+          url: mockArticleUrl,
+          message: "Optimized content from url='https://www.orf.at/stories/1234567890' is empty",
+        }),
+      );
     });
 
     test('content not found', async () => {
       mockedFetch.mockResolvedValue({ ok: false, text: () => Promise.reject(new Error('Content not found')) });
 
-      await expect(fetchStoryContent(mockArticleUrl)).rejects.toThrowError(ContentNotFoundError);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const error = Either.isLeft(result) ? result.left : undefined;
+
+      expect(error).toEqual(
+        new FetchError({
+          url: mockArticleUrl,
+        }),
+      );
     });
 
     test('adjust list with empty items', async () => {
@@ -117,7 +134,8 @@ describe('News content', () => {
         </ul>
       `);
 
-      const { content } = await fetchStoryContent(mockArticleUrl);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
 
       await expect(content).toBeHtml(`
         <div id="readability-page-1" class="page">
@@ -137,7 +155,8 @@ describe('News content', () => {
         <script>alert('Hello World');</script>
       `);
 
-      const { content } = await fetchStoryContent(mockArticleUrl);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
 
       await expect(content).toBeHtml(`
         <div id="readability-page-1" class="page">
@@ -155,7 +174,8 @@ describe('News content', () => {
         <p class="print-warning">Print warning</p>
       `);
 
-      const { content } = await fetchStoryContent(mockArticleUrl);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
 
       await expect(content).toBeHtml('<div id="readability-page-1" class="page"><p>Hello World</p></div>');
     });
@@ -168,7 +188,8 @@ describe('News content', () => {
         </section>
       `);
 
-      const { content } = await fetchStoryContent(mockArticleUrl);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
 
       await expect(content).toBeHtml('<div id="readability-page-1" class="page"><p>Hello World</p></div>');
     });
@@ -181,7 +202,8 @@ describe('News content', () => {
         </div>
       `);
 
-      const { content } = await fetchStoryContent(mockArticleUrl);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
 
       await expect(content).toBeHtml('<div id="readability-page-1" class="page"><p>Hello World</p></div>');
     });
@@ -194,7 +216,8 @@ describe('News content', () => {
         </nav>
       `);
 
-      const { content } = await fetchStoryContent(mockArticleUrl);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
 
       await expect(content).toBeHtml('<div id="readability-page-1" class="page"><p>Hello World</p></div>');
     });
@@ -205,7 +228,8 @@ describe('News content', () => {
         <a href="https://www.orf.at/#/article/1234567890">Article</a>
       `);
 
-      const { content } = await fetchStoryContent(mockArticleUrl);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
 
       await expect(content).toBeHtml('<div id="readability-page-1" class="page"><p>Hello World</p></div>');
     });
@@ -290,7 +314,10 @@ describe('News content', () => {
         ]),
       );
 
-      const { content, id, source } = await fetchStoryContent(mockArticleUrl, fetchReadMore);
+      const result = await fetchStoryContent(mockArticleUrl, fetchReadMore);
+      const content = Either.isRight(result) ? result.right.content : undefined;
+      const id = Either.isRight(result) ? result.right.id : undefined;
+      const source = Either.isRight(result) ? result.right.source : undefined;
 
       await expect(content).toBeHtml(expected);
       expect(id).toBe(expectedId);
@@ -771,7 +798,8 @@ describe('News content', () => {
     ])('$title', async ({ article, expected }) => {
       mockArticle(article);
 
-      const { content } = await fetchStoryContent(mockArticleUrl);
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
 
       await expect(content).toBeHtml(expected);
     });

--- a/src/lib/backend/content/news.spec.ts
+++ b/src/lib/backend/content/news.spec.ts
@@ -814,6 +814,107 @@ describe('News content', () => {
       await expect(content).toBeHtml(expected);
     });
   });
+
+  describe('Charts', () => {
+    test('replace chart with titled placeholder anchor', async () => {
+      const chartUrl = 'https://charts.orf.at/chart-1';
+      const article = `
+        <p>Hello World</p>
+        <div class="embed migsys">
+          <div class="migsys" data-mig-url="${chartUrl}"></div>
+        </div>
+      `;
+
+      mockedFetch.mockImplementation((url) => {
+        const requestedUrl = String(url);
+
+        if (requestedUrl === mockArticleUrl) {
+          return Promise.resolve({ ok: true, text: () => Promise.resolve(article) });
+        }
+        if (requestedUrl === `${chartUrl}/config.json`) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ title: '  Wahl 2026  ' }) });
+        }
+
+        return Promise.reject(new Error(`Unexpected request url: ${requestedUrl}`));
+      });
+
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
+
+      await expect(content).toBeHtml(`
+        <div id="readability-page-1" class="page">
+          <p>Hello World</p>
+          <a href="${mockArticleUrl}" target="_blank" rel="noopener noreferrer">Grafik zu „Wahl 2026“</a>
+        </div>
+      `);
+    });
+
+    test('replace chart with unknown placeholder anchor when chart data has no title', async () => {
+      const chartUrl = 'https://charts.orf.at/chart-2';
+      const article = `
+        <p>Hello World</p>
+        <div class="embed migsys">
+          <div class="migsys" data-mig-url="${chartUrl}"></div>
+        </div>
+      `;
+
+      mockedFetch.mockImplementation((url) => {
+        const requestedUrl = String(url);
+
+        if (requestedUrl === mockArticleUrl) {
+          return Promise.resolve({ ok: true, text: () => Promise.resolve(article) });
+        }
+        if (requestedUrl === `${chartUrl}/config.json`) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        }
+
+        return Promise.reject(new Error(`Unexpected request url: ${requestedUrl}`));
+      });
+
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
+
+      await expect(content).toBeHtml(`
+        <div id="readability-page-1" class="page">
+          <p>Hello World</p>
+          <a href="${mockArticleUrl}" target="_blank" rel="noopener noreferrer">Grafik zu „unbekannt“</a>
+        </div>
+      `);
+    });
+
+    test('replace chart with unknown placeholder anchor when chart request fails', async () => {
+      const chartUrl = 'https://charts.orf.at/chart-3';
+      const article = `
+        <p>Hello World</p>
+        <div class="embed migsys">
+          <div class="migsys" data-mig-url="${chartUrl}"></div>
+        </div>
+      `;
+
+      mockedFetch.mockImplementation((url) => {
+        const requestedUrl = String(url);
+
+        if (requestedUrl === mockArticleUrl) {
+          return Promise.resolve({ ok: true, text: () => Promise.resolve(article) });
+        }
+        if (requestedUrl === `${chartUrl}/config.json`) {
+          return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
+        }
+
+        return Promise.reject(new Error(`Unexpected request url: ${requestedUrl}`));
+      });
+
+      const result = await fetchStoryContent(mockArticleUrl);
+      const content = Either.isRight(result) ? result.right.content : undefined;
+
+      await expect(content).toBeHtml(`
+        <div id="readability-page-1" class="page">
+          <p>Hello World</p>
+          <a href="${mockArticleUrl}" target="_blank" rel="noopener noreferrer">Grafik zu „unbekannt“</a>
+        </div>
+      `);
+    });
+  });
 });
 
 function mockArticle(html: string | Map<string, string>): void {

--- a/src/lib/backend/content/news.spec.ts
+++ b/src/lib/backend/content/news.spec.ts
@@ -1,4 +1,4 @@
-import { FetchError, OptimizedContentIsEmptyError } from '$lib/errors/errors';
+import { ContentNotFoundError, OptimizedContentIsEmptyError } from '$lib/errors/errors';
 import { Either } from 'effect';
 import prettier from 'prettier';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -107,20 +107,30 @@ describe('News content', () => {
       expect(error).toEqual(
         new OptimizedContentIsEmptyError({
           url: mockArticleUrl,
+          tags: [['url', mockArticleUrl]],
           message: "Optimized content from url='https://www.orf.at/stories/1234567890' is empty",
         }),
       );
     });
 
     test('content not found', async () => {
-      mockedFetch.mockResolvedValue({ ok: false, text: () => Promise.reject(new Error('Content not found')) });
+      mockedFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.reject(new Error('Content not found')),
+      });
 
       const result = await fetchStoryContent(mockArticleUrl);
       const error = Either.isLeft(result) ? result.left : undefined;
 
       expect(error).toEqual(
-        new FetchError({
+        new ContentNotFoundError({
           url: mockArticleUrl,
+          tags: [
+            ['url', mockArticleUrl],
+            ['status', '404'],
+          ],
+          message: `Content from url='https://www.orf.at/stories/1234567890' cannot be loaded`,
         }),
       );
     });

--- a/src/lib/backend/content/news.ts
+++ b/src/lib/backend/content/news.ts
@@ -3,6 +3,7 @@ import { logger, STORY_CONTENT_READ_MORE_REGEXPS } from '$lib/configs/server';
 import {
   ContentNotFoundError,
   FetchError,
+  formatTags,
   MetaDataNotFoundError,
   OptimizedContentIsEmptyError,
   ParseError,
@@ -69,6 +70,7 @@ export function fetchStoryContent(
       logger.warn(`Error transforming content with url='${currentUrl}'`);
       return yield* new OptimizedContentIsEmptyError({
         url: currentUrl,
+        tags: [['url', currentUrl]],
         message: `Optimized content from url='${currentUrl}' is empty`,
       });
     }
@@ -94,9 +96,7 @@ export function fetchStoryContent(
   });
 
   return program.pipe(
-    Effect.tapError((error) =>
-      Effect.sync(() => logger.warn(`Failed to fetch content: url='${error.url}' error='${error}'`)),
-    ),
+    Effect.tapError((error) => Effect.sync(() => logger.warn(`Failed to fetch content: ${formatTags(error.tags)}`))),
     Effect.either,
     Effect.runPromise,
   );
@@ -108,34 +108,49 @@ function fetchStoryMetadata(
 ): Effect.Effect<Story, MetaDataNotFoundError> {
   return Effect.tryPromise({
     try: () => searchStory(url, { includeOesterreichSource }),
-    catch: (cause) =>
-      new MetaDataNotFoundError({ url, message: `Metadata for story with url='${url}' not found`, cause }),
-  }).pipe(
-    Effect.filterOrFail(
-      Predicate.isNotNullable,
-      () => new MetaDataNotFoundError({ url, message: `Metadata for story with url='${url}' not found` }),
-    ),
-  );
+    catch: (cause) => new MetaDataNotFoundError({ url, tags: [['url', url]], cause }),
+  }).pipe(Effect.filterOrFail(Predicate.isNotNullable, () => new MetaDataNotFoundError({ url, tags: [['url', url]] })));
 }
 
 function fetchSiteHtmlText(url: string): Effect.Effect<string, FetchError | ParseError | ContentNotFoundError> {
   return Effect.gen(function* () {
     const response = yield* Effect.tryPromise({
       try: () => fetch(url),
-      catch: (cause) => new FetchError({ url, cause }),
+      catch: (cause) =>
+        new FetchError({
+          url,
+          tags: [
+            ['url', url],
+            ['cause', (cause as Error).message],
+          ],
+          cause,
+        }),
     });
 
     if (!response.ok) {
       if (response.status === 404) {
-        return yield* new ContentNotFoundError({ url, message: `Content from url='${url}' cannot be loaded` });
+        return yield* new ContentNotFoundError({
+          url,
+          tags: [
+            ['url', url],
+            ['status', response.status.toString()],
+          ],
+          message: `Content from url='${url}' cannot be loaded`,
+        });
       } else {
-        return yield* new FetchError({ url });
+        return yield* new FetchError({
+          url,
+          tags: [
+            ['url', url],
+            ['status', response.status.toString()],
+          ],
+        });
       }
     }
 
     const text = yield* Effect.tryPromise({
       try: () => response.text(),
-      catch: (cause) => new ParseError({ url, cause }),
+      catch: (cause) => new ParseError({ url, tags: [['url', url]], cause }),
     });
 
     return text;
@@ -220,24 +235,36 @@ function fetchChartData(url: string | undefined): Effect.Effect<ChartData | unde
 
     const response = yield* Effect.tryPromise({
       try: () => fetch(`${url}/config.json`),
-      catch: (cause) => new FetchError({ url, cause }),
+      catch: (cause) =>
+        new FetchError({
+          url,
+          tags: [
+            ['url', url],
+            ['cause', (cause as Error).message],
+          ],
+          cause,
+        }),
     });
 
     if (!response.ok) {
-      return yield* new FetchError({ url });
+      return yield* new FetchError({
+        url,
+        tags: [
+          ['url', url],
+          ['status', response.status.toString()],
+        ],
+      });
     }
 
     const data = yield* Effect.tryPromise({
       try: () => response.json(),
-      catch: (cause) => new ParseError({ url, cause }),
+      catch: (cause) => new ParseError({ url, tags: [['url', url]], cause }),
     });
 
     const parsedData = ChartData.safeParse(data);
     return parsedData.data;
   }).pipe(
-    Effect.tapError((error) =>
-      Effect.sync(() => logger.warn(`Failed to fetch chart data: url='${error.url}' error='${error}'`)),
-    ),
+    Effect.tapError((error) => Effect.sync(() => logger.warn(`Failed to fetch chart data: ${formatTags(error.tags)}`))),
     Effect.catchAll(() => Effect.succeed(undefined)),
   );
 }

--- a/src/lib/backend/content/news.ts
+++ b/src/lib/backend/content/news.ts
@@ -234,7 +234,12 @@ function fetchChartData(url: string | undefined): Effect.Effect<ChartData | unde
 
     const parsedData = ChartData.safeParse(data);
     return parsedData.data;
-  }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+  }).pipe(
+    Effect.tapError((error) =>
+      Effect.sync(() => logger.warn(`Failed to fetch chart data: url='${error.url}' error='${error}'`)),
+    ),
+    Effect.catchAll(() => Effect.succeed(undefined)),
+  );
 }
 
 function removeSiteNavigation(optimizedDocument: Document): void {

--- a/src/lib/backend/content/news.ts
+++ b/src/lib/backend/content/news.ts
@@ -1,83 +1,139 @@
-import { Readability } from '@mozilla/readability';
-import { JSDOM } from 'jsdom';
-import createDOMPurify, { type WindowLike } from 'dompurify';
-import { ContentNotFoundError, OptimizedContentIsEmptyError } from '$lib/errors/errors';
-import { isOrfStoryUrl } from '$lib/utils/urls';
-import type { StoryContent, StorySource } from '$lib/models/story';
 import { searchStory } from '$lib/backend/db/news';
 import { logger, STORY_CONTENT_READ_MORE_REGEXPS } from '$lib/configs/server';
+import {
+  ContentNotFoundError,
+  FetchError,
+  MetaDataNotFoundError,
+  OptimizedContentIsEmptyError,
+  ParseError,
+  type FetchStoryContentError,
+} from '$lib/errors/errors';
+import { ChartData } from '$lib/models/charts';
+import type { Story, StoryContent, StorySource } from '$lib/models/story';
+import { isOrfStoryUrl } from '$lib/utils/urls';
+import { Readability } from '@mozilla/readability';
+import createDOMPurify, { type WindowLike } from 'dompurify';
+import { Effect, Either, Predicate } from 'effect';
+import { JSDOM } from 'jsdom';
 
 const ALLOWED_CLASSES = ['fact', 'keyword', 'slideshow'];
 
-export async function fetchStoryContent(url: string, fetchReadMoreContent = false): Promise<StoryContent> {
-  logger.info(`Fetch content with url='${url}' and fetchReadMoreContent='${fetchReadMoreContent}'`);
+export function fetchStoryContent(
+  url: string,
+  fetchReadMoreContent = false,
+): Promise<Either.Either<StoryContent, FetchStoryContentError>> {
+  const program = Effect.gen(function* () {
+    logger.info(`Fetch content with url='${url}' and fetchReadMoreContent='${fetchReadMoreContent}'`);
 
-  let currentUrl = url;
-  let [currentStory, currentData] = await Promise.all([
-    searchStory(currentUrl, { includeOesterreichSource: true }),
-    fetchSiteHtmlText(currentUrl),
-  ]);
-  let id;
-  let source;
-  let originalDocument = createDom(currentData, currentUrl);
+    let currentUrl = url;
+    let [currentStory, currentData] = yield* Effect.all([
+      fetchStoryMetadata(currentUrl, true),
+      fetchSiteHtmlText(currentUrl),
+    ]);
 
-  if (fetchReadMoreContent) {
-    const readMoreUrl = findReadMoreUrl(originalDocument);
+    let id;
+    let source;
+    let originalDocument = createDom(currentData, currentUrl);
 
-    if (readMoreUrl) {
-      try {
+    if (fetchReadMoreContent) {
+      const readMoreUrl = findReadMoreUrl(originalDocument);
+
+      if (readMoreUrl) {
         logger.info(`Fetch content with readMore url='${readMoreUrl}'`);
-        const [story, data] = await Promise.all([searchStory(readMoreUrl), fetchSiteHtmlText(readMoreUrl)]);
 
-        currentUrl = readMoreUrl;
-        currentStory = story;
-        currentData = data;
-        id = story?.id;
-        source = story?.source ?? findSourceFromUrl(currentUrl);
-        originalDocument = createDom(currentData, currentUrl);
-      } catch (error: unknown) {
-        logger.warn(`${(error as Error).message}`);
+        const result = yield* Effect.all([fetchStoryMetadata(readMoreUrl), fetchSiteHtmlText(readMoreUrl)]).pipe(
+          Effect.either,
+        );
+
+        if (Either.isRight(result)) {
+          const [story, data] = result.right;
+          currentUrl = readMoreUrl;
+          currentStory = story;
+          currentData = data;
+          id = story?.id;
+          source = story?.source ?? findSourceFromUrl(currentUrl);
+          originalDocument = createDom(currentData, currentUrl);
+        } else {
+          logger.warn(`Fetch content from readMore url not possible!`);
+        }
       }
     }
-  }
 
-  const document = createDom(currentData, currentUrl);
-  removePrintWarnings(document);
-  removeVideo(document);
-  removeMoreToReadSection(document);
-  await removeCharts(document, currentUrl);
-  const optimizedContent = new Readability(document, { classesToPreserve: ALLOWED_CLASSES }).parse();
-  if (!optimizedContent?.content) {
-    logger.warn(`Error transforming content with url='${currentUrl}'`);
-    throw new OptimizedContentIsEmptyError(`Optimized content from url='${currentUrl}' is empty`);
-  }
+    const document = createDom(currentData, currentUrl);
+    removePrintWarnings(document);
+    removeVideo(document);
+    removeMoreToReadSection(document);
+    yield* removeCharts(document, currentUrl);
+    const optimizedContent = new Readability(document, { classesToPreserve: ALLOWED_CLASSES }).parse();
+    if (!optimizedContent?.content) {
+      logger.warn(`Error transforming content with url='${currentUrl}'`);
+      return yield* new OptimizedContentIsEmptyError({
+        url: currentUrl,
+        message: `Optimized content from url='${currentUrl}' is empty`,
+      });
+    }
 
-  const optimizedDocument = createDom(optimizedContent.content, currentUrl);
-  removeSiteNavigation(optimizedDocument);
-  removeSiteAnchors(optimizedDocument);
-  injectSlideShowImages(optimizedDocument, originalDocument);
-  injectStoryFooter(optimizedDocument, originalDocument);
-  adjustAnchorTags(optimizedDocument);
-  adjustLists(optimizedDocument);
-  adjustTables(optimizedDocument);
+    const optimizedDocument = createDom(optimizedContent.content, currentUrl);
+    removeSiteNavigation(optimizedDocument);
+    removeSiteAnchors(optimizedDocument);
+    injectSlideShowImages(optimizedDocument, originalDocument);
+    injectStoryFooter(optimizedDocument, originalDocument);
+    adjustAnchorTags(optimizedDocument);
+    adjustLists(optimizedDocument);
+    adjustTables(optimizedDocument);
 
-  const storySource = source ? ({ name: source, url: currentUrl } satisfies StorySource) : undefined;
+    const storySource = source ? ({ name: source, url: currentUrl } satisfies StorySource) : undefined;
 
-  return {
-    content: sanitizeContent(optimizedDocument.body.innerHTML),
-    contentText: extractTextForSpeechSynthesis(optimizedDocument, originalDocument),
-    id,
-    timestamp: currentStory?.timestamp,
-    source: storySource,
-  };
+    return {
+      content: sanitizeContent(optimizedDocument.body.innerHTML),
+      contentText: extractTextForSpeechSynthesis(optimizedDocument, originalDocument),
+      id,
+      timestamp: currentStory?.timestamp,
+      source: storySource,
+    };
+  });
+
+  return program.pipe(
+    Effect.tapError((error) =>
+      Effect.sync(() => logger.warn(`Failed to fetch content: url='${error.url}' error='${error}'`)),
+    ),
+    Effect.either,
+    Effect.runPromise,
+  );
 }
 
-async function fetchSiteHtmlText(url: string): Promise<string> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new ContentNotFoundError(`Content from url='${url}' cannot be loaded`);
-  }
-  return response.text();
+function fetchStoryMetadata(
+  url: string,
+  includeOesterreichSource = false,
+): Effect.Effect<Story, MetaDataNotFoundError> {
+  return Effect.tryPromise({
+    try: () => searchStory(url, { includeOesterreichSource }),
+    catch: (cause) => new MetaDataNotFoundError({ url, cause }),
+  }).pipe(Effect.filterOrFail(Predicate.isNotNullable, () => new MetaDataNotFoundError({ url })));
+}
+
+function fetchSiteHtmlText(url: string): Effect.Effect<string, FetchError | ParseError | ContentNotFoundError> {
+  return Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () => fetch(url),
+      catch: (cause) => new FetchError({ url, cause }),
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return yield* new ContentNotFoundError({ url, message: `Content from url='${url}' cannot be loaded` });
+      } else {
+        return yield* new FetchError({ url });
+      }
+    }
+
+    const text = yield* Effect.tryPromise({
+      try: () => response.text(),
+      catch: (cause) => new ParseError({ url, cause }),
+    });
+
+    return text;
+  });
 }
 
 function createDom(data: string, url: string): Document {
@@ -132,38 +188,47 @@ function removeMoreToReadSection(document: Document): void {
   }
 }
 
-async function removeCharts(document: Document, url: string): Promise<void> {
-  const charts: Array<[Element, any]> = await Promise.all(
-    [...document.querySelectorAll('div.embed.migsys')].map((chart) => {
-      const dataMigUrl = chart.querySelector<HTMLDivElement>('div.migsys')?.dataset.migUrl;
-      return (async () => {
-        if (!dataMigUrl) {
-          return [chart, undefined];
-        }
+function removeCharts(document: Document, url: string): Effect.Effect<void> {
+  return Effect.gen(function* () {
+    const charts = yield* Effect.all(
+      [...document.querySelectorAll('div.embed.migsys')].map((chart) => {
+        const dataMigUrl = chart.querySelector<HTMLDivElement>('div.migsys')?.dataset.migUrl;
+        return Effect.all([Effect.succeed(chart), fetchChartData(dataMigUrl)]);
+      }),
+    );
 
-        try {
-          const response = await fetch(`${dataMigUrl}/config.json`);
-          if (!response.ok) {
-            return [chart, undefined];
-          }
+    for (const [chart, data] of charts) {
+      const placeholderAnchor = document.createElement('a');
+      placeholderAnchor.href = url;
+      placeholderAnchor.textContent = `Grafik zu „${data?.title?.trim() ?? 'unbekannt'}“`;
+      chart.replaceWith(placeholderAnchor);
+    }
+  });
+}
 
-          const data = await response.json();
-          return [chart, data];
-        } catch (error: unknown) {
-          logger.warn(`Error fetching chart data from url='${dataMigUrl}/config.json'. Error: ${error}`);
-          return [chart, undefined];
-        }
-      })();
-    }),
-  );
+function fetchChartData(url: string | undefined): Effect.Effect<ChartData | undefined> {
+  return Effect.gen(function* () {
+    if (!url) {
+      return undefined;
+    }
 
-  for (const [chart, data] of charts) {
-    const placeholderAnchor = document.createElement('a');
-    placeholderAnchor.href = url;
-    placeholderAnchor.textContent = `Grafik zu „${data?.title?.trim() ?? 'unbekannt'}“`;
+    const response = yield* Effect.tryPromise({
+      try: () => fetch(`${url}/config.json`),
+      catch: (cause) => new FetchError({ url, cause }),
+    });
 
-    chart.replaceWith(placeholderAnchor);
-  }
+    if (!response.ok) {
+      return yield* new FetchError({ url });
+    }
+
+    const data = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: (cause) => new ParseError({ url, cause }),
+    });
+
+    const parsedData = ChartData.safeParse(data);
+    return parsedData.data;
+  }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
 }
 
 function removeSiteNavigation(optimizedDocument: Document): void {

--- a/src/lib/backend/content/news.ts
+++ b/src/lib/backend/content/news.ts
@@ -108,8 +108,14 @@ function fetchStoryMetadata(
 ): Effect.Effect<Story, MetaDataNotFoundError> {
   return Effect.tryPromise({
     try: () => searchStory(url, { includeOesterreichSource }),
-    catch: (cause) => new MetaDataNotFoundError({ url, cause }),
-  }).pipe(Effect.filterOrFail(Predicate.isNotNullable, () => new MetaDataNotFoundError({ url })));
+    catch: (cause) =>
+      new MetaDataNotFoundError({ url, message: `Metadata for story with url='${url}' not found`, cause }),
+  }).pipe(
+    Effect.filterOrFail(
+      Predicate.isNotNullable,
+      () => new MetaDataNotFoundError({ url, message: `Metadata for story with url='${url}' not found` }),
+    ),
+  );
 }
 
 function fetchSiteHtmlText(url: string): Effect.Effect<string, FetchError | ParseError | ContentNotFoundError> {

--- a/src/lib/backend/content/news.ts
+++ b/src/lib/backend/content/news.ts
@@ -108,7 +108,15 @@ function fetchStoryMetadata(
 ): Effect.Effect<Story, MetaDataNotFoundError> {
   return Effect.tryPromise({
     try: () => searchStory(url, { includeOesterreichSource }),
-    catch: (cause) => new MetaDataNotFoundError({ url, tags: [['url', url]], cause }),
+    catch: (cause) =>
+      new MetaDataNotFoundError({
+        url,
+        tags: [
+          ['url', url],
+          ['cause', (cause as Error).message],
+        ],
+        cause,
+      }),
   }).pipe(Effect.filterOrFail(Predicate.isNotNullable, () => new MetaDataNotFoundError({ url, tags: [['url', url]] })));
 }
 

--- a/src/lib/backend/content/news.ts
+++ b/src/lib/backend/content/news.ts
@@ -55,7 +55,7 @@ export function fetchStoryContent(
           source = story?.source ?? findSourceFromUrl(currentUrl);
           originalDocument = createDom(currentData, currentUrl);
         } else {
-          logger.warn(`Fetch content from readMore url not possible!`);
+          logger.warn(`Failed to fetch content from readMore url: ${formatTags(result.left.tags)}`);
         }
       }
     }

--- a/src/lib/backend/content/news.ts
+++ b/src/lib/backend/content/news.ts
@@ -32,8 +32,8 @@ export function fetchStoryContent(
       fetchSiteHtmlText(currentUrl),
     ]);
 
-    let id;
-    let source;
+    let id: string | undefined = undefined;
+    let source: string | undefined = undefined;
     let originalDocument = createDom(currentData, currentUrl);
 
     if (fetchReadMoreContent) {

--- a/src/lib/backend/trpc/router.ts
+++ b/src/lib/backend/trpc/router.ts
@@ -5,6 +5,8 @@ import {
 } from '$lib/configs/server';
 import { API_VERSION } from '$lib/configs/shared';
 import { SearchRequest } from '$lib/models/searchRequest';
+import { TRPCError } from '@trpc/server';
+import { Either } from 'effect';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
 import { isOrfUrl } from '../../utils/urls';
@@ -41,11 +43,30 @@ const news = {
     .query(async ({ input, ctx }) => {
       const { url, fetchReadMoreContent } = input;
       const content = await fetchStoryContent(url, fetchReadMoreContent);
-      const maxage = getMaxAge(content.timestamp);
+      if (Either.isLeft(content)) {
+        switch (content.left._tag) {
+          case 'MetaDataNotFoundError':
+          case 'ContentNotFoundError': {
+            throw new TRPCError({
+              code: 'NOT_FOUND',
+              message: content.left.message,
+            });
+          }
+          default: {
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: 'Unknown error',
+              cause: content.left,
+            });
+          }
+        }
+      }
+
+      const maxage = getMaxAge(content.right.timestamp);
       ctx.event.setHeaders({
         'Cache-Control': `max-age=0, s-maxage=${maxage}`,
       });
-      return content;
+      return content.right;
     }),
 };
 

--- a/src/lib/errors/errors.ts
+++ b/src/lib/errors/errors.ts
@@ -11,6 +11,7 @@ export class FetchError extends Data.TaggedError('FetchError')<{ url: string; ca
 export class ParseError extends Data.TaggedError('ParseError')<{ url: string; cause?: unknown }> {}
 export class MetaDataNotFoundError extends Data.TaggedError('MetaDataNotFoundError')<{
   url: string;
+  message: string;
   cause?: unknown;
 }> {}
 export class ContentNotFoundError extends Data.TaggedError('ContentNotFoundError')<{ url: string; message: string }> {}

--- a/src/lib/errors/errors.ts
+++ b/src/lib/errors/errors.ts
@@ -1,8 +1,23 @@
 import { Data } from 'effect';
 
 // Story content
-export class ContentNotFoundError extends Error {}
-export class OptimizedContentIsEmptyError extends Error {}
+export type FetchStoryContentError =
+  | FetchError
+  | ParseError
+  | MetaDataNotFoundError
+  | ContentNotFoundError
+  | OptimizedContentIsEmptyError;
+export class FetchError extends Data.TaggedError('FetchError')<{ url: string; cause?: unknown }> {}
+export class ParseError extends Data.TaggedError('ParseError')<{ url: string; cause?: unknown }> {}
+export class MetaDataNotFoundError extends Data.TaggedError('MetaDataNotFoundError')<{
+  url: string;
+  cause?: unknown;
+}> {}
+export class ContentNotFoundError extends Data.TaggedError('ContentNotFoundError')<{ url: string; message: string }> {}
+export class OptimizedContentIsEmptyError extends Data.TaggedError('OptimizedContentIsEmptyError')<{
+  url: string;
+  message: string;
+}> {}
 
 // AI
 export const AiServiceErrorTypes = ['INVALID_REQUEST', 'TIMEOUT', 'RATE_LIMIT'] as const;

--- a/src/lib/errors/errors.ts
+++ b/src/lib/errors/errors.ts
@@ -1,5 +1,13 @@
 import { Data } from 'effect';
 
+// Error Tags
+export type Tags = Array<Tag>;
+export type Tag = [string, string];
+
+export function formatTags(tags: Tags): string {
+  return tags.map(([key, value]) => `${key}='${value}'`).join(', ');
+}
+
 // Story content
 export type FetchStoryContentError =
   | FetchError
@@ -7,16 +15,21 @@ export type FetchStoryContentError =
   | MetaDataNotFoundError
   | ContentNotFoundError
   | OptimizedContentIsEmptyError;
-export class FetchError extends Data.TaggedError('FetchError')<{ url: string; cause?: unknown }> {}
-export class ParseError extends Data.TaggedError('ParseError')<{ url: string; cause?: unknown }> {}
+export class FetchError extends Data.TaggedError('FetchError')<{ url: string; tags: Tags; cause?: unknown }> {}
+export class ParseError extends Data.TaggedError('ParseError')<{ url: string; tags: Tags; cause?: unknown }> {}
 export class MetaDataNotFoundError extends Data.TaggedError('MetaDataNotFoundError')<{
   url: string;
-  message: string;
+  tags: Tags;
   cause?: unknown;
 }> {}
-export class ContentNotFoundError extends Data.TaggedError('ContentNotFoundError')<{ url: string; message: string }> {}
+export class ContentNotFoundError extends Data.TaggedError('ContentNotFoundError')<{
+  url: string;
+  tags: Tags;
+  message: string;
+}> {}
 export class OptimizedContentIsEmptyError extends Data.TaggedError('OptimizedContentIsEmptyError')<{
   url: string;
+  tags: Tags;
   message: string;
 }> {}
 

--- a/src/lib/models/charts.ts
+++ b/src/lib/models/charts.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const ChartData = z.object({
+  title: z.string(),
+});
+export type ChartData = z.infer<typeof ChartData>;

--- a/src/lib/utils/http.ts
+++ b/src/lib/utils/http.ts
@@ -1,0 +1,3 @@
+export function is4xxError(code?: number | undefined): boolean {
+  return code !== undefined && code >= 400 && code < 500;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of news content errors with clear not-found vs internal responses.
  * Read-more fetch failures no longer break main content — they're logged and skipped.
  * API query retry behavior standardized to avoid retrying on client (4xx) errors.

* **New Features**
  * Chart configuration now validated to prevent rendering invalid charts.

* **Tests**
  * Expanded tests covering content fetch failure modes and chart rendering fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->