### PR TITLE
Add option to change match mode

### DIFF
--- a/src/lib/components/news/filter/NewsFilter.svelte
+++ b/src/lib/components/news/filter/NewsFilter.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { browser } from '$app/environment';
-  import NewsFilterOtherPopover from '$lib/components/news/filter/NewsFilterOtherPopover.svelte';
   import Input from '$lib/components/shared/controls/Input.svelte';
+  import type { SearchMatchMode } from '$lib/models/searchRequest';
   import { startSearch } from '$lib/stores/newsEvents';
   import searchFilter from '$lib/stores/searchFilter';
   import { isMac } from '$lib/utils/platform';
@@ -9,6 +9,7 @@
   import { unsubscribeAll, type Subscription } from '$lib/utils/subscriptions';
   import { isTouchDevice } from '$lib/utils/support';
   import { onDestroy, onMount } from 'svelte';
+  import NewsFilterMenuPopover from './NewsFilterMenuPopover.svelte';
   import NewsFilterTagPopover from './NewsFilterTagPopover.svelte';
 
   const subscriptions: Array<Subscription> = [];
@@ -56,6 +57,10 @@
   function handleDateFilterToChange(to?: string): void {
     searchFilter.setTo(to);
   }
+
+  function handleMatchModeChange(matchMode: SearchMatchMode): void {
+    searchFilter.setMatchMode(matchMode);
+  }
 </script>
 
 <div class={filterClass} id="news-filter">
@@ -70,13 +75,15 @@
     bind:this={textFilterInputRef}
   />
   <NewsFilterTagPopover onSelectTag={handleSelectTag} />
-  <NewsFilterOtherPopover
-    from={$searchFilter.tempDateFilter?.from}
-    to={$searchFilter.tempDateFilter?.to}
+  <NewsFilterMenuPopover
+    from={$searchFilter.temp?.dateFilter?.from}
+    to={$searchFilter.temp?.dateFilter?.to}
+    matchMode={$searchFilter.temp?.matchMode}
     onFromChange={handleDateFilterFromChange}
     onToChange={handleDateFilterToChange}
+    onMatchModeChange={handleMatchModeChange}
     onApply={searchFilter.applyTempSearchFilter}
-    onReset={searchFilter.resetDateFilter}
+    onReset={searchFilter.resetTempFilters}
     onSelectToday={searchFilter.selectDateFilterToday}
     onSelectLastWeek={searchFilter.selectDateFilterLastWeek}
     onSelectLastMonth={searchFilter.selectDateFilterLastMonth}

--- a/src/lib/components/news/filter/NewsFilterMenuPopover.svelte
+++ b/src/lib/components/news/filter/NewsFilterMenuPopover.svelte
@@ -4,15 +4,19 @@
   import TextGradient from '$lib/components/shared/content/TextGradient.svelte';
   import Button from '$lib/components/shared/controls/Button.svelte';
   import DatePicker from '$lib/components/shared/controls/DatePicker.svelte';
-  import { Calendar, Funnel } from '@steeze-ui/heroicons';
+  import Select from '$lib/components/shared/controls/Select.svelte';
+  import { SearchMatchMode } from '$lib/models/searchRequest';
+  import { Calendar, Funnel, MagnifyingGlass } from '@steeze-ui/heroicons';
   import { Icon } from '@steeze-ui/svelte-icon';
   import type { DateTime } from 'luxon';
 
   interface Props {
     from?: DateTime;
     to?: DateTime;
+    matchMode?: SearchMatchMode;
     onFromChange?: (from?: string) => void;
     onToChange?: (to?: string) => void;
+    onMatchModeChange?: (matchMode: SearchMatchMode) => void;
     onApply?: () => void;
     onReset?: () => void;
     onSelectToday?: () => void;
@@ -24,8 +28,10 @@
   let {
     from,
     to,
+    matchMode,
     onFromChange,
     onToChange,
+    onMatchModeChange,
     onApply,
     onReset,
     onSelectToday,
@@ -33,6 +39,17 @@
     onSelectLastMonth,
     onSelectLastYear,
   }: Props = $props();
+
+  const searchModeOptions: Array<{ label: string; value: SearchMatchMode }> = [
+    {
+      label: 'Mindestens eines',
+      value: 'anyOf',
+    },
+    {
+      label: 'Alle',
+      value: 'allOf',
+    },
+  ];
 
   const menuClass = `
     flex flex-col items-center gap-5
@@ -51,6 +68,11 @@
 
   function handleToChange(to?: DateTime): void {
     onToChange?.(to?.endOf('day').toISO() ?? undefined);
+  }
+
+  function handleMatchModeChange(matchMode?: string): void {
+    const parsedMatchMode = SearchMatchMode.safeParse(matchMode);
+    onMatchModeChange?.(parsedMatchMode?.data ?? 'anyOf');
   }
 
   function handleApplyClick(): void {
@@ -111,6 +133,17 @@
           <label for="to-input">Bis</label>
           <DatePicker id="to-input" value={to} placeholder="Bis" onchange={handleToChange} />
         </div>
+      </section>
+      <section class={menuSectionClass}>
+        <span class={menuSectionTitleClass}>
+          <Icon src={MagnifyingGlass} theme="outlined" class="size-6" />
+          <TextGradient>Suchmodus</TextGradient>
+        </span>
+        <Select id="search-mode" value={matchMode} onchange={handleMatchModeChange} placeholder="Suchmodus">
+          {#each searchModeOptions as option (option.value)}
+            <option value={option.value}>{option.label}</option>
+          {/each}
+        </Select>
       </section>
       <div class={menuActionsClass}>
         <Button

--- a/src/lib/models/searchRequest.ts
+++ b/src/lib/models/searchRequest.ts
@@ -7,19 +7,19 @@ export const DateFilter = z.object({
 });
 export type DateFilter = z.infer<typeof DateFilter>;
 
+export const SearchMatchMode = z.enum(['anyOf', 'allOf']);
+export type SearchMatchMode = z.infer<typeof SearchMatchMode>;
+
 export const SearchFilter = z.object({
   tag: z.string().optional(),
   textFilter: z.string().optional(),
   dateFilter: DateFilter.optional(),
+  matchMode: SearchMatchMode.optional(),
 });
 export type SearchFilter = z.infer<typeof SearchFilter>;
 
-export const SearchMatchMode = z.enum(['anyOf', 'allOf']);
-export type SearchMatchMode = z.infer<typeof SearchMatchMode>;
-
 export const SearchRequestParameters = SearchFilter.extend({
   sources: z.array(z.string()).optional(),
-  matchMode: SearchMatchMode.optional(),
 });
 export type SearchRequestParameters = z.infer<typeof SearchRequestParameters>;
 

--- a/src/lib/stores/searchFilter.ts
+++ b/src/lib/stores/searchFilter.ts
@@ -1,4 +1,4 @@
-import type { SearchFilter } from '$lib/models/searchRequest';
+import type { SearchFilter, SearchMatchMode } from '$lib/models/searchRequest';
 import { DateTime, type DurationLike } from 'luxon';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { type Readable, type Subscriber } from 'svelte/store';
@@ -8,10 +8,13 @@ export type InternalDateFilter = {
   to?: DateTime;
 };
 
-export interface SearchFilterStoreProps extends Omit<SearchFilter, 'dateFilter'> {
+export interface InternalSearchFilter extends Omit<SearchFilter, 'dateFilter'> {
   tag?: string;
   dateFilter?: InternalDateFilter;
-  tempDateFilter?: InternalDateFilter;
+  matchMode?: SearchMatchMode;
+}
+export interface SearchFilterStoreProps extends InternalSearchFilter {
+  temp?: Omit<InternalSearchFilter, 'tag'>;
 }
 
 export interface SearchFilterStore extends Readable<SearchFilterStoreProps> {
@@ -21,8 +24,9 @@ export interface SearchFilterStore extends Readable<SearchFilterStoreProps> {
   resetTag: () => void;
   setFrom: (fromDate: string | undefined) => void;
   setTo: (toDate: string | undefined) => void;
+  setMatchMode: (matchMode: SearchMatchMode) => void;
   applyTempSearchFilter: () => void;
-  resetDateFilter: () => void;
+  resetTempFilters: () => void;
   resetAll: () => void;
   selectDateFilterToday: () => void;
   selectDateFilterLastWeek: () => void;
@@ -31,15 +35,19 @@ export interface SearchFilterStore extends Readable<SearchFilterStoreProps> {
 }
 
 const initialState = (): SearchFilterStoreProps => ({
-  textFilter: '',
   tag: undefined,
+  textFilter: '',
   dateFilter: {
     from: undefined,
     to: undefined,
   },
-  tempDateFilter: {
-    from: undefined,
-    to: undefined,
+  matchMode: 'anyOf',
+  temp: {
+    dateFilter: {
+      from: undefined,
+      to: undefined,
+    },
+    matchMode: 'anyOf',
   },
 });
 
@@ -69,30 +77,44 @@ function resetTag(): void {
 function setFrom(from?: string): void {
   const newFrom = from ? DateTime.fromISO(from).startOf('day') : undefined;
   update((searchFilter) => {
-    const to = searchFilter.tempDateFilter?.to;
+    const to = searchFilter.temp?.dateFilter?.to;
     const newTo = !to || !newFrom || newFrom <= to ? to : newFrom.endOf('day');
-    return { ...searchFilter, tempDateFilter: { from: newFrom, to: newTo } };
+    return { ...searchFilter, temp: { ...searchFilter.temp, dateFilter: { from: newFrom, to: newTo } } };
   });
 }
 
 function setTo(to?: string): void {
   const newTo = to ? DateTime.fromISO(to).endOf('day') : undefined;
   update((searchFilter) => {
-    const from = searchFilter.tempDateFilter?.from;
+    const from = searchFilter.temp?.dateFilter?.from;
     const newFrom = !from || !newTo || from <= newTo ? from : newTo.startOf('day');
-    return { ...searchFilter, tempDateFilter: { from: newFrom, to: newTo } };
+    return { ...searchFilter, temp: { ...searchFilter.temp, dateFilter: { from: newFrom, to: newTo } } };
   });
 }
 
-function applyTempSearchFilter(): void {
-  update((searchFilter) => ({ ...searchFilter, dateFilter: searchFilter.tempDateFilter }));
+function setMatchMode(matchMode: SearchMatchMode): void {
+  update((searchFilter) => ({ ...searchFilter, temp: { ...searchFilter.temp, matchMode } }));
 }
 
-function resetDateFilter(): void {
+function applyTempSearchFilter(): void {
+  update((searchFilter) => ({ ...searchFilter, ...searchFilter.temp }));
+}
+
+function resetTempFilters(): void {
   update((searchFilter) => ({
     ...searchFilter,
-    dateFilter: {},
-    tempDateFilter: {},
+    dateFilter: {
+      from: undefined,
+      to: undefined,
+    },
+    matchMode: 'anyOf',
+    temp: {
+      dateFilter: {
+        from: undefined,
+        to: undefined,
+      },
+      matchMode: 'anyOf',
+    },
   }));
 }
 
@@ -149,11 +171,12 @@ export default {
   resetTag,
   setFrom,
   setTo,
+  setMatchMode,
   applyTempSearchFilter,
-  resetDateFilter,
+  resetTempFilters,
   resetAll,
   selectDateFilterToday,
   selectDateFilterLastWeek,
   selectDateFilterLastMonth,
   selectDateFilterLastYear,
-} as SearchFilterStore;
+} satisfies SearchFilterStore;

--- a/src/lib/stores/searchFilter.ts
+++ b/src/lib/stores/searchFilter.ts
@@ -126,7 +126,7 @@ function selectDateFilterToday(): void {
   const [from, to] = dateRangeFromNow({});
   update((searchFilter) => ({
     ...searchFilter,
-    tempDateFilter: { from, to },
+    temp: { ...searchFilter.temp, dateFilter: { from, to } },
   }));
 }
 
@@ -134,7 +134,7 @@ function selectDateFilterLastWeek(): void {
   const [from, to] = dateRangeFromNow({ weeks: 1 });
   update((searchFilter) => ({
     ...searchFilter,
-    tempDateFilter: { from, to },
+    temp: { ...searchFilter.temp, dateFilter: { from, to } },
   }));
 }
 
@@ -142,7 +142,7 @@ function selectDateFilterLastMonth(): void {
   const [from, to] = dateRangeFromNow({ months: 1 });
   update((searchFilter) => ({
     ...searchFilter,
-    tempDateFilter: { from, to },
+    temp: { ...searchFilter.temp, dateFilter: { from, to } },
   }));
 }
 
@@ -150,7 +150,7 @@ function selectDateFilterLastYear(): void {
   const [from, to] = dateRangeFromNow({ years: 1 });
   update((searchFilter) => ({
     ...searchFilter,
-    tempDateFilter: { from, to },
+    temp: { ...searchFilter.temp, dateFilter: { from, to } },
   }));
 }
 

--- a/src/lib/stores/searchRequestParameters.ts
+++ b/src/lib/stores/searchRequestParameters.ts
@@ -6,10 +6,11 @@ import settings from './settings';
 
 function searchFilterStorePropsEqual(p1?: SearchFilterStoreProps, p2?: SearchFilterStoreProps): boolean {
   return (
-    p1?.textFilter === p2?.textFilter &&
     p1?.tag === p2?.tag &&
+    p1?.textFilter === p2?.textFilter &&
     datesEqual(p1?.dateFilter?.from, p2?.dateFilter?.from) &&
-    datesEqual(p1?.dateFilter?.to, p2?.dateFilter?.to)
+    datesEqual(p1?.dateFilter?.to, p2?.dateFilter?.to) &&
+    p1?.matchMode === p2?.matchMode
   );
 }
 
@@ -62,7 +63,7 @@ searchFilter.observable
       );
     }),
     map(([searchFilter, sources]) => {
-      const { textFilter, tag, dateFilter } = searchFilter ?? {};
+      const { textFilter, tag, dateFilter, matchMode } = searchFilter ?? {};
       return {
         tag,
         textFilter,
@@ -71,7 +72,7 @@ searchFilter.observable
           to: dateFilter?.to?.toISO() ?? undefined,
         },
         sources,
-        matchMode: 'anyOf',
+        matchMode,
       } satisfies SearchRequestParameters;
     }),
   )

--- a/tests/pages/news.page.ts
+++ b/tests/pages/news.page.ts
@@ -29,7 +29,7 @@ export class NewsPage {
     return this.newsFilter.getByTitle('Schlagwörter');
   }
 
-  get newsFilterOtherMenuButton(): Locator {
+  get newsFilterMenuButton(): Locator {
     return this.newsFilter.getByTitle('Weitere Filter-Optionen');
   }
 
@@ -39,6 +39,10 @@ export class NewsPage {
 
   get textFilterClearButton(): Locator {
     return this.newsFilter.locator('input + button');
+  }
+
+  get matchModeFilter(): Locator {
+    return this.popover.getByPlaceholder('Suchmodus');
   }
 
   get newsListItems(): Locator {

--- a/tests/pages/news.page.ts
+++ b/tests/pages/news.page.ts
@@ -45,6 +45,14 @@ export class NewsPage {
     return this.popover.getByPlaceholder('Suchmodus');
   }
 
+  get applyTempFiltersButton(): Locator {
+    return this.popover.getByRole('button', { name: 'Anwenden' });
+  }
+
+  get resetTempFiltersButton(): Locator {
+    return this.popover.getByRole('button', { name: 'Zurücksetzen' });
+  }
+
   get newsListItems(): Locator {
     return this.page.locator('#news ul > li');
   }

--- a/tests/specs/news.spec.ts
+++ b/tests/specs/news.spec.ts
@@ -93,6 +93,28 @@ test.describe('NewsPage', () => {
       await newsPage.matchModeFilter.selectOption('allOf');
       await expect(newsPage.matchModeFilter).toHaveValue('allOf');
     });
+
+    test('apply and reset temp filters', async ({ newsPage }) => {
+      await newsPage.newsFilterMenuButton.click();
+      await newsPage.getDateFilterInput('Von').fill('01.01.2026');
+      await newsPage.getDateFilterInput('Bis').fill('31.01.2026');
+      await newsPage.matchModeFilter.selectOption('allOf');
+      await newsPage.applyTempFiltersButton.click();
+      await expect(newsPage.popover).not.toBeVisible();
+
+      await newsPage.newsFilterMenuButton.click();
+      await expect(newsPage.getDateFilterInput('Von')).toHaveValue('01.01.2026');
+      await expect(newsPage.getDateFilterInput('Bis')).toHaveValue('31.01.2026');
+      await expect(newsPage.matchModeFilter).toHaveValue('allOf');
+
+      await newsPage.resetTempFiltersButton.click();
+      await expect(newsPage.popover).not.toBeVisible();
+
+      await newsPage.newsFilterMenuButton.click();
+      await expect(newsPage.getDateFilterInput('Von')).toHaveValue('');
+      await expect(newsPage.getDateFilterInput('Bis')).toHaveValue('');
+      await expect(newsPage.matchModeFilter).toHaveValue('anyOf');
+    });
   });
 
   test.describe('Sections', () => {

--- a/tests/specs/news.spec.ts
+++ b/tests/specs/news.spec.ts
@@ -82,9 +82,16 @@ test.describe('NewsPage', () => {
     });
 
     test('date filter is changeable', async ({ newsPage }) => {
-      await newsPage.newsFilterOtherMenuButton.click();
+      await newsPage.newsFilterMenuButton.click();
       await expect(newsPage.getDateFilterInput('Von')).toBeEditable();
       await expect(newsPage.getDateFilterInput('Bis')).toBeEditable();
+    });
+
+    test('match mode filter is changeable', async ({ newsPage }) => {
+      await newsPage.newsFilterMenuButton.click();
+      await expect(newsPage.matchModeFilter).toHaveValue('anyOf');
+      await newsPage.matchModeFilter.selectOption('allOf');
+      await expect(newsPage.matchModeFilter).toHaveValue('allOf');
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Suchmodus" (search match mode) option to news filters, letting users switch between matching any or all search terms; integrated into the filter menu with apply/reset behavior.
* **Tests**
  * Updated UI tests to cover the new match mode control and the apply/reset temp-filters flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->