### PR TITLE
feat: add color scheme toggle to header

### DIFF
--- a/src/lib/components/settings/appearance/Appearance.svelte
+++ b/src/lib/components/settings/appearance/Appearance.svelte
@@ -26,13 +26,12 @@
     },
   ];
 
-  let colorScheme: ColorScheme = $state($styles.colorScheme);
-
-  function handleColorSchemeRadioChange(_value: string): void {
-    if (colorScheme) {
+  function handleColorSchemeRadioChange(value: string): void {
+    const scheme = value as ColorScheme;
+    if (scheme) {
       runViewTransition(
         () => {
-          styles.setColorScheme(colorScheme);
+          styles.setColorScheme(scheme);
         },
         {
           useReducedMotion: reducedMotionStore.useReducedMotion,
@@ -63,7 +62,7 @@
           name="color-scheme"
           label={option.label}
           value={option.value}
-          bind:group={colorScheme}
+          bind:group={$styles.colorScheme}
           onchange={handleColorSchemeRadioChange.bind(null, option.value)}
           onclick={handleColorSchemeRadioClick}
           onkeydown={handleColorSchemeRadioKeydown}

--- a/src/lib/components/settings/appearance/Appearance.svelte
+++ b/src/lib/components/settings/appearance/Appearance.svelte
@@ -59,7 +59,7 @@
           name="color-scheme"
           label={option.label}
           value={option.value}
-          bind:group={$styles.colorScheme}
+          group={$styles.colorScheme}
           onchange={handleColorSchemeRadioChange.bind(null, option.value)}
           onclick={handleColorSchemeRadioClick}
           onkeydown={handleColorSchemeRadioKeydown}

--- a/src/lib/components/settings/appearance/Appearance.svelte
+++ b/src/lib/components/settings/appearance/Appearance.svelte
@@ -24,20 +24,17 @@
       label: 'Dunkel',
       value: 'dark',
     },
-  ];
+  ] as const;
 
-  function handleColorSchemeRadioChange(value: string): void {
-    const scheme = value as ColorScheme;
-    if (scheme) {
-      runViewTransition(
-        () => {
-          styles.setColorScheme(scheme);
-        },
-        {
-          useReducedMotion: reducedMotionStore.useReducedMotion,
-        },
-      );
-    }
+  function handleColorSchemeRadioChange(value: ColorScheme): void {
+    runViewTransition(
+      () => {
+        styles.setColorScheme(value);
+      },
+      {
+        useReducedMotion: reducedMotionStore.useReducedMotion,
+      },
+    );
   }
 
   function handleColorSchemeRadioClick(event: MouseEvent): void {

--- a/src/lib/components/shared/app/AppLayout.svelte
+++ b/src/lib/components/shared/app/AppLayout.svelte
@@ -20,6 +20,7 @@
   import EnableGlobalKeybindings from './EnableGlobalKeybindings.svelte';
   import EnableNetworkNotifications from './EnableNetworkNotifications.svelte';
   import EnableUpdateListener from './EnableUpdateListener.svelte';
+  import { setEffectiveColorSchemeStore } from '$lib/stores/runes/effectiveColorScheme.svelte';
 
   interface Props {
     children?: Snippet;
@@ -30,6 +31,7 @@
   const reducedMotionStore = setReducedMotionStore();
   setSkeletonStore();
   setAudioStore();
+  setEffectiveColorSchemeStore();
 
   const infoApi = new InfoApi();
 

--- a/src/lib/components/shared/app/AppLayout.svelte
+++ b/src/lib/components/shared/app/AppLayout.svelte
@@ -3,6 +3,7 @@
   import { InfoApi } from '$lib/api/info';
   import { API_VERSION } from '$lib/configs/shared';
   import { setAudioStore } from '$lib/stores/runes/audio.svelte';
+  import { setEffectiveColorSchemeStore } from '$lib/stores/runes/effectiveColorScheme.svelte';
   import { setReducedMotionStore } from '$lib/stores/runes/reducedMotion.svelte';
   import { setSkeletonStore } from '$lib/stores/runes/skeleton.svelte';
   import { logger } from '$lib/utils/logger';
@@ -20,7 +21,6 @@
   import EnableGlobalKeybindings from './EnableGlobalKeybindings.svelte';
   import EnableNetworkNotifications from './EnableNetworkNotifications.svelte';
   import EnableUpdateListener from './EnableUpdateListener.svelte';
-  import { setEffectiveColorSchemeStore } from '$lib/stores/runes/effectiveColorScheme.svelte';
 
   interface Props {
     children?: Snippet;

--- a/src/lib/components/shared/content/Header.svelte
+++ b/src/lib/components/shared/content/Header.svelte
@@ -91,6 +91,7 @@
       <Icon src={BookmarkSquare} theme="outlined" class="size-6" />
     </ButtonLink>
     <Button
+      class="max-sm:hidden"
       title={isDark ? 'Zum hellen Modus wechseln' : 'Zum dunklen Modus wechseln'}
       iconOnly
       btnType="secondary"

--- a/src/lib/components/shared/content/Header.svelte
+++ b/src/lib/components/shared/content/Header.svelte
@@ -91,16 +91,37 @@
       <Icon src={BookmarkSquare} theme="outlined" class="size-6" />
     </ButtonLink>
     <Button
-      class="max-sm:hidden"
+      class="max-sm:hidden theme-toggle"
       title={isDark ? 'Zum hellen Modus wechseln' : 'Zum dunklen Modus wechseln'}
       iconOnly
       btnType="secondary"
       onclick={handleColorSchemeButtonClick}
     >
-      <Icon src={isDark ? Moon : Sun} theme="outlined" class="size-6" />
+      <Icon src={Sun} theme="outlined" class="size-6 theme-sun" />
+      <Icon src={Moon} theme="outlined" class="size-6 theme-moon" />
     </Button>
     <ButtonLink href={resolve('/settings')} title="Einstellungen" iconOnly prefetch>
       <Icon src={Cog8Tooth} theme="outlined" class="size-6" />
     </ButtonLink>
   </nav>
 </header>
+
+<style>
+  :global(.theme-toggle) {
+    :global(.theme-sun) {
+      display: block;
+    }
+    :global(.theme-moon) {
+      display: none;
+    }
+  }
+
+  :global(:root.dark .theme-toggle) {
+    :global(.theme-sun) {
+      display: none;
+    }
+    :global(.theme-moon) {
+      display: block;
+    }
+  }
+</style>

--- a/src/lib/components/shared/content/Header.svelte
+++ b/src/lib/components/shared/content/Header.svelte
@@ -6,10 +6,11 @@
   import ButtonLink from '$lib/components/shared/controls/ButtonLink.svelte';
   import { NOTIFICATION_OFFLINE_CACHE_DOWNLOADED } from '$lib/configs/client';
   import news from '$lib/stores/news';
+  import styles, { getEffectiveColorScheme } from '$lib/stores/styles';
   import { refreshNews } from '$lib/stores/newsEvents';
   import notifications from '$lib/stores/notifications';
   import { defaultPadding } from '$lib/utils/styles';
-  import { ArrowPath, BookmarkSquare, CloudArrowDown, Cog8Tooth, Newspaper } from '@steeze-ui/heroicons';
+  import { ArrowPath, BookmarkSquare, CloudArrowDown, Cog8Tooth, Moon, Newspaper, Sun } from '@steeze-ui/heroicons';
   import { Icon } from '@steeze-ui/svelte-icon';
   import Button from '../controls/Button.svelte';
 
@@ -25,6 +26,7 @@
   const headerActionsClass = 'flex gap-2';
 
   let isNewsPage = $derived(page.url.pathname === '/');
+  let isDark = $derived(getEffectiveColorScheme($styles.colorScheme) === 'dark');
 
   function handleRefreshButtonClick(): void {
     refreshNews.notify();
@@ -72,6 +74,14 @@
     <ButtonLink href={resolve('/bookmarks')} title="Lesezeichen" iconOnly prefetch>
       <Icon src={BookmarkSquare} theme="outlined" class="size-6" />
     </ButtonLink>
+    <Button
+      title={isDark ? 'Zum hellen Modus wechseln' : 'Zum dunklen Modus wechseln'}
+      iconOnly
+      btnType="secondary"
+      onclick={() => styles.setColorScheme(isDark ? 'light' : 'dark')}
+    >
+      <Icon src={isDark ? Moon : Sun} theme="outlined" class="size-6" />
+    </Button>
     <ButtonLink href={resolve('/settings')} title="Einstellungen" iconOnly prefetch>
       <Icon src={Cog8Tooth} theme="outlined" class="size-6" />
     </ButtonLink>

--- a/src/lib/components/shared/content/Header.svelte
+++ b/src/lib/components/shared/content/Header.svelte
@@ -6,14 +6,19 @@
   import ButtonLink from '$lib/components/shared/controls/ButtonLink.svelte';
   import { NOTIFICATION_OFFLINE_CACHE_DOWNLOADED } from '$lib/configs/client';
   import news from '$lib/stores/news';
-  import styles, { getEffectiveColorScheme } from '$lib/stores/styles';
   import { refreshNews } from '$lib/stores/newsEvents';
   import notifications from '$lib/stores/notifications';
+  import { getEffectiveColorSchemeStore } from '$lib/stores/runes/effectiveColorScheme.svelte';
+  import { getReducedMotionStore } from '$lib/stores/runes/reducedMotion.svelte';
+  import styles from '$lib/stores/styles';
   import { defaultPadding } from '$lib/utils/styles';
+  import { runViewTransition } from '$lib/utils/viewTransition';
   import { ArrowPath, BookmarkSquare, CloudArrowDown, Cog8Tooth, Moon, Newspaper, Sun } from '@steeze-ui/heroicons';
   import { Icon } from '@steeze-ui/svelte-icon';
   import Button from '../controls/Button.svelte';
 
+  const effectiveColorSchemeStore = getEffectiveColorSchemeStore();
+  const reducedMotionStore = getReducedMotionStore();
   const newsApi = new NewsApi();
 
   const headerClass = `
@@ -26,7 +31,7 @@
   const headerActionsClass = 'flex gap-2';
 
   let isNewsPage = $derived(page.url.pathname === '/');
-  let isDark = $derived(getEffectiveColorScheme($styles.colorScheme) === 'dark');
+  let isDark = $derived(effectiveColorSchemeStore.effectiveColorScheme === 'dark');
 
   function handleRefreshButtonClick(): void {
     refreshNews.notify();
@@ -44,6 +49,17 @@
       replaceInCategory: true,
       forceAppNotification: true,
     });
+  }
+
+  function handleColorSchemeButtonClick(): void {
+    runViewTransition(
+      () => {
+        styles.setColorScheme(isDark ? 'light' : 'dark');
+      },
+      {
+        useReducedMotion: reducedMotionStore.useReducedMotion,
+      },
+    );
   }
 </script>
 
@@ -78,7 +94,7 @@
       title={isDark ? 'Zum hellen Modus wechseln' : 'Zum dunklen Modus wechseln'}
       iconOnly
       btnType="secondary"
-      onclick={() => styles.setColorScheme(isDark ? 'light' : 'dark')}
+      onclick={handleColorSchemeButtonClick}
     >
       <Icon src={isDark ? Moon : Sun} theme="outlined" class="size-6" />
     </Button>

--- a/src/lib/components/shared/controls/Radio.svelte
+++ b/src/lib/components/shared/controls/Radio.svelte
@@ -1,13 +1,13 @@
-<script lang="ts" generics="T">
+<script lang="ts" generics="TValue extends string">
   import { inputClass, labelClass, wrapperClass } from './checkbox.styles';
 
   interface Props {
     id: string;
     name: string;
     label: string;
-    value: T;
-    group: string;
-    onchange?: (value: T) => void;
+    value: TValue;
+    group: TValue;
+    onchange?: (value: TValue) => void;
     onclick?: (event: MouseEvent) => void;
     onkeydown?: (event: KeyboardEvent) => void;
   }

--- a/src/lib/components/shared/controls/Radio.svelte
+++ b/src/lib/components/shared/controls/Radio.svelte
@@ -1,13 +1,13 @@
-<script lang="ts">
+<script lang="ts" generics="T">
   import { inputClass, labelClass, wrapperClass } from './checkbox.styles';
 
   interface Props {
     id: string;
     name: string;
     label: string;
-    value: string;
+    value: T;
     group: string;
-    onchange?: (value: string) => void;
+    onchange?: (value: T) => void;
     onclick?: (event: MouseEvent) => void;
     onkeydown?: (event: KeyboardEvent) => void;
   }

--- a/src/lib/stores/runes/audio.svelte.ts
+++ b/src/lib/stores/runes/audio.svelte.ts
@@ -236,13 +236,13 @@ class AudioStore implements AudioStoreInterface {
   }
 }
 
-const DEFAULT_KEY = 'root_audio_store';
+const DEFAULT_KEY = Symbol('root_audio_store');
 
-export function getAudioStore(key: string = DEFAULT_KEY): AudioStoreInterface {
+export function getAudioStore(key: symbol = DEFAULT_KEY): AudioStoreInterface {
   return getContext(key);
 }
 
-export function setAudioStore(key: string = DEFAULT_KEY): AudioStoreInterface {
+export function setAudioStore(key: symbol = DEFAULT_KEY): AudioStoreInterface {
   const audioStore = new AudioStore();
   audioStore.init();
   return setContext(key, audioStore);

--- a/src/lib/stores/runes/effectiveColorScheme.svelte.ts
+++ b/src/lib/stores/runes/effectiveColorScheme.svelte.ts
@@ -1,8 +1,7 @@
+import { getContext, setContext } from 'svelte';
 import { MediaQuery } from 'svelte/reactivity';
-import styles, { type ColorScheme } from '../styles';
 import { fromStore } from 'svelte/store';
-import { setContext } from 'svelte';
-import { getContext } from 'svelte';
+import styles, { type ColorScheme } from '../styles';
 
 export interface EffectiveColorSchemeStoreInterface {
   effectiveColorScheme: Exclude<ColorScheme, 'system'>;

--- a/src/lib/stores/runes/effectiveColorScheme.svelte.ts
+++ b/src/lib/stores/runes/effectiveColorScheme.svelte.ts
@@ -1,0 +1,34 @@
+import { MediaQuery } from 'svelte/reactivity';
+import styles, { type ColorScheme } from '../styles';
+import { fromStore } from 'svelte/store';
+import { setContext } from 'svelte';
+import { getContext } from 'svelte';
+
+export interface EffectiveColorSchemeStoreInterface {
+  effectiveColorScheme: ColorScheme;
+}
+
+export class EffectiveColorSchemeStore implements EffectiveColorSchemeStoreInterface {
+  private prefersDarkColorScheme = new MediaQuery('(prefers-color-scheme: dark)');
+  private styles = fromStore(styles);
+
+  effectiveColorScheme = $derived.by(() => {
+    const prefersDarkColorScheme = this.prefersDarkColorScheme.current;
+    if (this.styles.current.colorScheme === 'system') {
+      return prefersDarkColorScheme ? 'dark' : 'light';
+    }
+
+    return this.styles.current.colorScheme;
+  });
+}
+
+const DEFAULT_KEY = Symbol('root_effective_color_scheme_store');
+
+export function getEffectiveColorSchemeStore(key: symbol = DEFAULT_KEY): EffectiveColorSchemeStoreInterface {
+  return getContext(key);
+}
+
+export function setEffectiveColorSchemeStore(key: symbol = DEFAULT_KEY): EffectiveColorSchemeStoreInterface {
+  const effectiveColorSchemeStore = new EffectiveColorSchemeStore();
+  return setContext(key, effectiveColorSchemeStore);
+}

--- a/src/lib/stores/runes/effectiveColorScheme.svelte.ts
+++ b/src/lib/stores/runes/effectiveColorScheme.svelte.ts
@@ -5,7 +5,7 @@ import { setContext } from 'svelte';
 import { getContext } from 'svelte';
 
 export interface EffectiveColorSchemeStoreInterface {
-  effectiveColorScheme: ColorScheme;
+  effectiveColorScheme: Exclude<ColorScheme, 'system'>;
 }
 
 export class EffectiveColorSchemeStore implements EffectiveColorSchemeStoreInterface {

--- a/src/lib/stores/runes/reducedMotion.svelte.ts
+++ b/src/lib/stores/runes/reducedMotion.svelte.ts
@@ -19,13 +19,13 @@ class ReducedMotionStore implements ReducedMotionStoreInterface {
   }
 }
 
-const DEFAULT_KEY = 'root_reduced_motion_store';
+const DEFAULT_KEY = Symbol('root_reduced_motion_store');
 
-export function getReducedMotionStore(key: string = DEFAULT_KEY): ReducedMotionStoreInterface {
+export function getReducedMotionStore(key: symbol = DEFAULT_KEY): ReducedMotionStoreInterface {
   return getContext(key);
 }
 
-export function setReducedMotionStore(key: string = DEFAULT_KEY): ReducedMotionStoreInterface {
+export function setReducedMotionStore(key: symbol = DEFAULT_KEY): ReducedMotionStoreInterface {
   const reducedMotionStore = new ReducedMotionStore();
   return setContext(key, reducedMotionStore);
 }

--- a/src/lib/stores/runes/skeleton.svelte.ts
+++ b/src/lib/stores/runes/skeleton.svelte.ts
@@ -13,13 +13,13 @@ class SkeletonStore implements SkeletonStoreInterface {
   );
 }
 
-const DEFAULT_KEY = 'root_skeleton_store';
+const DEFAULT_KEY = Symbol('root_skeleton_store');
 
-export function getSkeletonStore(key: string = DEFAULT_KEY): SkeletonStoreInterface {
+export function getSkeletonStore(key: symbol = DEFAULT_KEY): SkeletonStoreInterface {
   return getContext(key);
 }
 
-export function setSkeletonStore(key: string = DEFAULT_KEY): SkeletonStoreInterface {
+export function setSkeletonStore(key: symbol = DEFAULT_KEY): SkeletonStoreInterface {
   const skeletonStore = new SkeletonStore();
   return setContext(key, skeletonStore);
 }

--- a/src/lib/stores/styles.ts
+++ b/src/lib/stores/styles.ts
@@ -50,4 +50,20 @@ function setColorScheme(colorScheme: ColorScheme): void {
   update((styles) => ({ ...styles, colorScheme }));
 }
 
+/**
+ * Returns the effective (visually active) color scheme.
+ * Resolves 'system' against the OS preference via matchMedia.
+ * @param colorScheme — the store's colorScheme value ('light' | 'dark' | 'system')
+ *                      or undefined as a safety net (falls back to 'system')
+ */
+export function getEffectiveColorScheme(colorScheme: ColorScheme | undefined): ColorScheme {
+  if (colorScheme === 'system') {
+    if (browser) {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    return 'light';
+  }
+  return colorScheme ?? 'system';
+}
+
 export default { subscribe, setColorScheme } as StylesStore;

--- a/src/lib/stores/styles.ts
+++ b/src/lib/stores/styles.ts
@@ -9,7 +9,7 @@ export interface StylesStoreProps {
   colorScheme: ColorScheme;
 }
 
-export interface StylesStore extends Readable<StylesStoreProps>, Partial<StylesStoreProps> {
+export interface StylesStore extends Readable<StylesStoreProps> {
   setColorScheme: (colorScheme: ColorScheme) => void;
 }
 
@@ -50,20 +50,4 @@ function setColorScheme(colorScheme: ColorScheme): void {
   update((styles) => ({ ...styles, colorScheme }));
 }
 
-/**
- * Returns the effective (visually active) color scheme.
- * Resolves 'system' against the OS preference via matchMedia.
- * @param colorScheme — the store's colorScheme value ('light' | 'dark' | 'system')
- *                      or undefined as a safety net (falls back to 'system')
- */
-export function getEffectiveColorScheme(colorScheme: ColorScheme | undefined): ColorScheme {
-  if (colorScheme === 'system') {
-    if (browser) {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    return 'light';
-  }
-  return colorScheme ?? 'system';
-}
-
-export default { subscribe, setColorScheme } as StylesStore;
+export default { subscribe, setColorScheme } satisfies StylesStore;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a theme toggle button in the header to switch between light and dark color schemes.
- “System” color scheme now automatically follows the user’s device dark-mode preference.
- Theme switching uses view transitions for smoother updates and respects reduced-motion settings.
- Sun/Moon icons and the theme tooltip update to reflect the active theme.
- Color-scheme selection stays synchronized with the currently active scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->